### PR TITLE
[ITONOMY-795] Defensive coding

### DIFF
--- a/Model/Product/Type.php
+++ b/Model/Product/Type.php
@@ -16,15 +16,11 @@ class Type extends \Magento\Bundle\Model\Product\Type
      */
     protected function getQty($selection, $qtys, $selectionOptionId)
     {
-        if ($selection->getSelectionCanChangeQty() && isset($qtys[$selectionOptionId])) {
-            $qty = (float)$qtys[$selectionOptionId] > 0 ? $qtys[$selectionOptionId] : 1;
-        } elseif (isset($qtys[$selectionOptionId][$selection->getId()])) {
-            $qty = (float)$qtys[$selectionOptionId][$selection->getId()] ? $qtys[$selectionOptionId][$selection->getId()] : 1;
+        if ($selection->getSelectionCanChangeQty()) {
+            $qty = $qtys[$selectionOptionId] ?? 1.0;
         } else {
-            $qty = (float)$selection->getSelectionQty() ? $selection->getSelectionQty() : 1;
+            $qty = $selection->getSelectionQty();
         }
-        $qty = (float)$qty;
-
-        return $qty;
+        return (float) \max($qty , 1.0);
     }
 }


### PR DESCRIPTION
Hi @andyschofieuk,

Here's a little change to the preference class. Although I could not reproduce the issue with the 2.4.2/2.3.7-p1 versions of Magento2,  I made the class just a bit more defensive given Magento stores the value as different data types in different places. I tested this locally and don't get any issues whatsoever changing qty for options that have can_change_qty set to 1.